### PR TITLE
Add Flask-based OCR parser

### DIFF
--- a/README
+++ b/README
@@ -1,7 +1,0 @@
-echo "# Teste" >> README.md
-git init
-git add README.md
-git commit -m "first commit"
-git branch -M main
-git remote add origin https://github.com/jvictorsantos79/Teste.git
-git push -u origin main

--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# Ferramenta de Controle de Comparecimento
+
+Este projeto fornece uma pequena aplicação web que extrai dados de arquivos de imagem e PDF contendo listas de eleitores. Os dados são convertidos para uma tabela com as colunas **CNF**, **Nome**, **Comparecimento**, **Local** e **Urna**. Também é possível pesquisar por nome ou CNF.
+
+## Como usar
+
+1. Instale as dependências (é necessário ter o `tesseract` instalado no sistema):
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Execute a aplicação:
+
+```bash
+python app.py
+```
+
+3. Acesse `http://localhost:5000` no navegador. Utilize o formulário para enviar arquivos PDF ou imagens contendo a tabela de eleitores.
+
+Os registros extraídos ficam salvos no arquivo `data.csv`.
+
+## Estrutura
+
+- `app.py` – aplicação Flask responsável por receber uploads, executar OCR e armazenar os dados.
+- `templates/index.html` – página HTML simples para upload e pesquisa.
+- `data.csv` – arquivo utilizado para armazenar os dados extraídos.
+
+## Observação
+
+O método de extração é baseado em OCR simples e pode exigir ajustes de acordo com o formato real dos arquivos de origem.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,105 @@
+import csv
+import os
+import tempfile
+
+from flask import Flask, render_template, request, redirect, url_for
+from werkzeug.utils import secure_filename
+
+import pytesseract
+from PIL import Image
+import pdfplumber
+
+DATA_FILE = 'data.csv'
+ALLOWED_EXTENSIONS = {'pdf', 'png', 'jpg', 'jpeg'}
+
+app = Flask(__name__)
+
+
+def allowed_file(filename):
+    return '.' in filename and filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
+
+
+def parse_table(text):
+    rows = []
+    for line in text.splitlines():
+        parts = line.split()
+        if len(parts) >= 5 and parts[0].isdigit():
+            cnf = parts[0]
+            urna = parts[-1]
+            local = parts[-2]
+            comparecimento = parts[-3]
+            nome = ' '.join(parts[1:-3])
+            rows.append([cnf, nome, comparecimento, local, urna])
+    return rows
+
+
+def read_image(path):
+    image = Image.open(path)
+    text = pytesseract.image_to_string(image, lang='por')
+    return text
+
+
+def read_pdf(path):
+    text = ''
+    with pdfplumber.open(path) as pdf:
+        for page in pdf.pages:
+            text += page.extract_text() + '\n'
+    return text
+
+
+def save_rows(rows):
+    file_exists = os.path.isfile(DATA_FILE)
+    with open(DATA_FILE, 'a', newline='', encoding='utf-8') as f:
+        writer = csv.writer(f)
+        if not file_exists:
+            writer.writerow(['CNF', 'Nome', 'Comparecimento', 'Local', 'Urna'])
+        writer.writerows(rows)
+
+
+def load_rows(query=None):
+    rows = []
+    if not os.path.isfile(DATA_FILE):
+        return rows
+    with open(DATA_FILE, newline='', encoding='utf-8') as f:
+        reader = csv.reader(f)
+        next(reader, None)  # skip header
+        for row in reader:
+            if query:
+                if query.lower() in row[0].lower() or query.lower() in row[1].lower():
+                    rows.append(row)
+            else:
+                rows.append(row)
+    return rows
+
+
+@app.route('/', methods=['GET'])
+def index():
+    q = request.args.get('q')
+    rows = load_rows(q)
+    return render_template('index.html', rows=rows)
+
+
+@app.route('/upload', methods=['POST'])
+def upload():
+    file = request.files.get('file')
+    if not file or not allowed_file(file.filename):
+        return redirect(url_for('index'))
+
+    filename = secure_filename(file.filename)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, filename)
+        file.save(path)
+        ext = filename.rsplit('.', 1)[1].lower()
+        if ext == 'pdf':
+            text = read_pdf(path)
+        else:
+            text = read_image(path)
+
+    rows = parse_table(text)
+    if rows:
+        save_rows(rows)
+    return redirect(url_for('index'))
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/data.csv
+++ b/data.csv
@@ -1,0 +1,1 @@
+CNF,Nome,Comparecimento,Local,Urna

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Flask
+pytesseract
+pdfplumber
+pillow

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="pt-br">
+<head>
+    <meta charset="utf-8">
+    <title>Leitor de Eleitores</title>
+</head>
+<body>
+    <h1>Importar lista de eleitores</h1>
+    <form action="/upload" method="post" enctype="multipart/form-data">
+        <input type="file" name="file">
+        <button type="submit">Enviar</button>
+    </form>
+    <h2>Pesquisar</h2>
+    <form method="get" action="/">
+        <input type="text" name="q" placeholder="Buscar por nome ou CNF" value="{{ request.args.get('q','') }}">
+        <button type="submit">Buscar</button>
+    </form>
+    {% if rows %}
+    <h2>Resultados</h2>
+    <table border="1">
+        <thead>
+            <tr>
+                <th>CNF</th>
+                <th>Nome</th>
+                <th>Comparecimento</th>
+                <th>Local</th>
+                <th>Urna</th>
+            </tr>
+        </thead>
+        <tbody>
+        {% for r in rows %}
+            <tr>
+                <td>{{ r[0] }}</td>
+                <td>{{ r[1] }}</td>
+                <td>{{ r[2] }}</td>
+                <td>{{ r[3] }}</td>
+                <td>{{ r[4] }}</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+    {% endif %}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add basic Flask app with OCR using pytesseract and pdfplumber
- store results in `data.csv`
- simple HTML upload/search interface
- add dependencies in `requirements.txt`
- update README with usage instructions

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6886eccd28cc832d9bc35c50a9046f5a